### PR TITLE
Added type-C route

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -15,37 +15,51 @@ describe('auth redirect behavior', () => {
     id: 'id',
   };
 
-  test('anonymous user is redirected to sign-in from authenticated', async () => {
-    const {app, store} = renderApp(AppPaths.AUTHENTICATED);
-
-    // FIXME: For some reason, all pages are not rendered in enzyme (correctly rendered IRL)
-    //  Expected: `SignIn` should be found.
-    expect(store.getState().auth.user).toBeNull();
-    expect(app.find(Authenticated)).toHaveLength(0);
-    expect(app.find(SignIn)).toHaveLength(0);
-  });
-
   test('anonymous user can go to the home page', () => {
     const {app, store} = renderApp(AppPaths.HOME);
 
     expect(store.getState().auth.user).toBeNull();
-    expect(app.find(SignUp)).toHaveLength(0);
-    expect(app.find(Homepage)).toHaveLength(1);
+    expect(app.find(SignUp).exists()).toBeFalsy();
+    expect(app.find(Homepage).exists()).toBeTruthy();
+  });
+
+  test('anonymous user is redirected to sign-in from authenticated', async () => {
+    const {app, store} = renderApp(AppPaths.AUTHENTICATED);
+
+    expect(store.getState().auth.user).toBeNull();
+    expect(app.find(Authenticated).exists()).toBeFalsy();
+    expect(app.find(SignIn).exists()).toBeTruthy();
+  });
+
+  test('anonymous user can go to the sign-in page', () => {
+    const {app, store} = renderApp(AppPaths.SIGN_IN);
+
+    expect(store.getState().auth.user).toBeNull();
+    expect(app.find(Homepage).exists()).toBeFalsy();
+    expect(app.find(SignIn).exists()).toBeTruthy();
+  });
+
+  test('logged in user can go to the home page', () => {
+    const {app, store} = renderApp(AppPaths.HOME);
+
+    expect(store.getState().auth.user).toBeNull();
+    expect(app.find(SignUp).exists()).toBeFalsy();
+    expect(app.find(Homepage).exists()).toBeTruthy();
   });
 
   test('logged in user is redirected from sign-in to authenticated', () => {
     const {app, store} = renderApp(AppPaths.SIGN_IN, {auth: {user: testUser}});
 
-    expect(app.find(SignUp)).toHaveLength(0);
-    expect(app.find(Authenticated)).toHaveLength(1);
+    expect(app.find(SignIn).exists()).toBeFalsy();
+    expect(app.find(Authenticated).exists()).toBeTruthy();
     expect(store.getState().auth.user).toBe(testUser);
   });
 
-  test('logged in user can go to authenticated', () => {
+  test('logged in user can go to authenticated page', () => {
     const {app, store} = renderApp(AppPaths.AUTHENTICATED, {auth: {user: testUser}});
 
-    expect(app.find(SignUp)).toHaveLength(0);
-    expect(app.find(Authenticated)).toHaveLength(1);
+    expect(app.find(SignIn).exists()).toBeFalsy();
+    expect(app.find(Authenticated).exists()).toBeTruthy();
     expect(store.getState().auth.user).toBe(testUser);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import {Container, makeStyles} from '@material-ui/core';
-import {BrowserRouter} from 'react-router-dom';
 
 import './App.css';
 import Copyright from './components/elements/Copyright';
 import {GlobalAlert} from './components/elements/GlobalAlert';
 import {Navigation} from './components/elements/nav/Main';
+import {AnonymousRoute} from './components/elements/routes/AnonymousRoute';
 import {PrivateRoute} from './components/elements/routes/PrivateRoute';
 import {PublicRoute} from './components/elements/routes/PublicRoute';
 import {Authenticated} from './components/pages/Authenticated';
@@ -41,20 +41,23 @@ const PageContent = () => {
     <Container className={classes.root}>
       <GlobalAlert/>
 
-      {/* Anonymous users only */}
+      {/* Accessible regardless the login status */}
 
       <PublicRoute path={AppPaths.HOME}>
         <Homepage/>
       </PublicRoute>
-      <PublicRoute path={AppPaths.SIGN_UP}>
+
+      {/* Anonymous users only */}
+
+      <AnonymousRoute path={AppPaths.SIGN_UP}>
         <SignUp/>
-      </PublicRoute>
-      <PublicRoute path={AppPaths.SIGN_IN}>
+      </AnonymousRoute>
+      <AnonymousRoute path={AppPaths.SIGN_IN}>
         <SignIn/>
-      </PublicRoute>
-      <PublicRoute path={AppPaths.FORGOT_PASSWORD}>
+      </AnonymousRoute>
+      <AnonymousRoute path={AppPaths.FORGOT_PASSWORD}>
         <ForgotPassword/>
-      </PublicRoute>
+      </AnonymousRoute>
 
       {/* Authentication needed */}
 
@@ -62,7 +65,6 @@ const PageContent = () => {
         <Authenticated/>
       </PrivateRoute>
 
-      {/* Common routes */}
       <Copyright/>
     </Container>
   );
@@ -92,9 +94,7 @@ const AppPage = () => {
 const App = (props: ReduxProviderProps) => {
   return (
     <ReduxProvider {...props}>
-      <BrowserRouter>
-        <AppPage/>
-      </BrowserRouter>
+      <AppPage/>
     </ReduxProvider>
   );
 };

--- a/src/components/elements/routes/AnonymousRoute.tsx
+++ b/src/components/elements/routes/AnonymousRoute.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
 
-import {Route} from 'react-router-dom';
+import {Redirect, Route} from 'react-router-dom';
 
+import AppPaths from '../../../const/paths';
 import {User} from '../../../state/auth/data';
 import {useAuthSelector} from '../../../state/auth/selector';
 import {RouteCommonProps} from './props';
 
-type PublicRouteProps = RouteCommonProps;
+type UnauthedRouteProps = RouteCommonProps;
 
-const renderRoute = (user: User | null, {children}: React.PropsWithChildren<PublicRouteProps>) => () => {
+const renderRoute = (user: User | null, {children}: React.PropsWithChildren<UnauthedRouteProps>) => () => {
+  if (user != null) { // `==` for checking `null` or `undefined`
+    return <Redirect to={AppPaths.AUTHENTICATED}/>;
+  }
+
   return children;
 };
 
-export const PublicRoute = (props: React.PropsWithChildren<PublicRouteProps>) => {
+export const AnonymousRoute = (props: React.PropsWithChildren<UnauthedRouteProps>) => {
   // Do not move this `useSelector` inside `renderRoute`, it causes an invalid use of hook
   // https://reactjs.org/warnings/invalid-hook-call-warning.html
   const {user} = useAuthSelector();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 
 import ReactDOM from 'react-dom';
+import {BrowserRouter} from 'react-router-dom';
 
 import App from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
 
 ReactDOM.render(
-  <App/>,
+  <BrowserRouter>
+    <App/>
+  </BrowserRouter>,
   document.getElementById('root'),
 );
 

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -1,8 +1,9 @@
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import Enzyme, {mount, ReactWrapper} from 'enzyme';
 import React from 'react';
 
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import Enzyme, {mount, ReactWrapper} from 'enzyme';
 import {MemoryRouter} from 'react-router-dom';
+
 import App from '../src/App';
 import AppPaths from '../src/const/paths';
 import {PartialReduxState} from '../src/state/state';


### PR DESCRIPTION
For details on routes, check #19.

- The original `PublicRoute` is now type-C.
- The route for unauthed user (type-B) is called `AnonymousRoute`.
- Moved `<BrowserRouter>` to `index.tsx` because it blocks `MemoryRouter` for testing.
- Fixes the false negative in #23 by changing the app initializing pattern.

Closes #19. Fixes #23.